### PR TITLE
initial implementation and tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+indent_style = space
+insert_final_newline = true
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,154 @@
+name: Tests
+
+on: [pull_request, push]
+
+jobs:
+  tests:
+    env:
+      NPROC: 2
+    strategy:
+      fail-fast: false
+      matrix:
+        cache_nonce: [ 1 ]
+        nim_version: [ 1.2.18, 1.4.8, 1.6.4 ]
+        platform:
+          - {
+            icon: 🐧,
+            label: Linux,
+            os: ubuntu,
+            shell: bash --noprofile --norc -eo pipefail
+          }
+          - {
+            icon: 🍎,
+            label: macOS,
+            os: macos,
+            shell: bash --noprofile --norc -eo pipefail
+          }
+          - {
+            icon: 🏁,
+            label: Windows,
+            os: windows,
+            shell: msys2
+          }
+    name: ${{ matrix.platform.icon }} ${{ matrix.platform.label }} - Nim v${{ matrix.nim_version }}
+    runs-on: ${{ matrix.platform.os }}-latest
+    defaults:
+      run:
+        shell: ${{ matrix.platform.shell }} {0}
+
+    steps:
+      # - name: Install tools and libraries via APT (Linux)
+      #   if: matrix.platform.os == 'ubuntu'
+      #   run: |
+      #     sudo apt update
+      #     sudo apt install -y \
+      #       ...
+
+      - name: Install tools and libraries via Homebrew (macOS)
+        if: matrix.platform.os == 'macos'
+        run: |
+          brew update
+          brew install \
+            findutils \
+            libomp
+
+      - name: Install tools and libraries via MSYS2 (Windows)
+        if: matrix.platform.os == 'windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          install: >
+            base-devel
+            git
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-toolchain
+
+      - name: Checkout sources from GitHub
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Calculate cache member paths
+        id: calc-paths
+        run: |
+          if [[ ${{ matrix.platform.os }} = windows ]]; then
+            echo "::set-output name=bash_env::$(cygpath -m "${HOME}")/.bash_env"
+            echo "::set-output name=choosenim::$(cygpath -m "${USERPROFILE}")/.choosenim"
+            echo "::set-output name=nimble::$(cygpath -m "${HOME}")/.nimble"
+          else
+            echo "::set-output name=bash_env::${HOME}/.bash_env"
+            echo "::set-output name=choosenim::${HOME}/.choosenim"
+            echo "::set-output name=nimble::${HOME}/.nimble"
+          fi
+
+      - name: Restore choosenim and Nim tooling from cache
+        id: choosenim-nim-tooling-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.calc-paths.outputs.bash_env }}
+            ${{ steps.calc-paths.outputs.choosenim }}
+            ${{ steps.calc-paths.outputs.nimble }}/bin
+          key: ${{ matrix.platform.os }}-nim_version:${{ matrix.nim_version }}-cache_nonce:${{ matrix.cache_nonce }}
+
+      - name: Install choosenim and Nim tooling
+        if: steps.choosenim-nim-tooling-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "${HOME}/Downloads"
+          cd "${HOME}/Downloads"
+          curl https://nim-lang.org/choosenim/init.sh -sSf -O
+          chmod +x init.sh
+          if [[ ${{ matrix.platform.os }} = windows ]]; then
+            mkdir -p "$(cygpath "${USERPROFILE}")/.nimble/bin"
+          fi
+          CHOOSENIM_CHOOSE_VERSION=${{ matrix.nim_version }} ./init.sh -y
+          if [[ ${{ matrix.platform.os }} = windows ]]; then
+            mv "$(cygpath "${USERPROFILE}")/.nimble" "${HOME}/"
+            # intention is to rely only on libs provided by the OS and MSYS2 env
+            rm -rf "${HOME}/.nimble/bin/"*.dll
+            rm -rf "${HOME}/.nimble/bin/"*.pem
+          fi
+          echo 'export NIMBLE_DIR="${HOME}/.nimble"' >> "${HOME}/.bash_env"
+          echo 'export PATH="${NIMBLE_DIR}/bin:${PATH}"' >> "${HOME}/.bash_env"
+
+      - name: Install project dependencies
+        run: |
+          source "${HOME}/.bash_env"
+          cd "${NIMBLE_DIR}/bin"
+          # delete broken symlinks, which can arise because e.g. the cache
+          # restored a symlink that points to an executable within
+          # ../pkgs/foo-1.2.3/ but the project's .nimble file has been updated
+          # to install foo-#head. In the case of a broken symlink, nimble's
+          # auto-overwrite fails (only sometimes? only on macOS?)
+          if [[ ${{ matrix.platform.os }} = macos ]]; then
+            gfind . -xtype l -delete
+          else
+            find . -xtype l -delete
+          fi
+          cd -
+          nimble --accept install
+
+      - name: Build and run tests
+        run: |
+          source "${HOME}/.bash_env"
+          if [[ ${{ matrix.platform.os }} = windows ]]; then
+            touch tests/test_leopard.exe
+          else
+            touch tests/test_leopard
+          fi
+          if [[ ${{ matrix.platform.os }} = macos ]]; then
+            export PATH="$(brew --prefix)/opt/llvm/bin:${PATH}"
+            export LDFLAGS="-L$(brew --prefix)/opt/libomp/lib -L$(brew --prefix)/opt/llvm/lib -Wl,-rpath,$(brew --prefix)/opt/llvm/lib"
+            nimble test -d:verbose -d:release -d:LeopardCmakeFlags="-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$(brew --prefix)/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix)/opt/llvm/bin/clang++" -d:LeopardExtraCompilerlags="-fopenmp" -d:LeopardExtraLinkerFlags="-fopenmp -L$(brew --prefix)/opt/libomp/lib"
+          else
+            nimble test -d:verbose -d:release
+          fi
+          if [[ ${{ matrix.platform.os }} = macos ]]; then
+            echo
+            echo otool -L tests/test_leopard
+            otool -L tests/test_leopard
+          else
+            echo
+            echo ldd tests/test_leopard
+            ldd tests/test_leopard
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*
+!*/
+!*.*
+*.a
+*.dll
+*.dylib
+*.exe
+*.so
+.DS_Store
+.idea
+.vscode
+leopard.nims
+TODO

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "vendor/leopard"]
 	path = vendor/leopard
-	url = https://github.com/catid/leopard.git
+	url = https://github.com/status-im/leopard.git
 	ignore = untracked
 	branch = master

--- a/README.md
+++ b/README.md
@@ -7,6 +7,73 @@
 
 Nim wrapper for [Leopard-RS](https://github.com/catid/leopard): a fast library for [Reed-Solomon](https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction) erasure correction coding.
 
+## Requirements
+
+* Same as Leopard-RS' requirements, e.g. CMake 3.7 or newer.
+* Nim 1.2 or newer.
+
+
+## Installation
+
+With [Nimble](https://github.com/nim-lang/nimble)
+```text
+$ nimble install leopard
+```
+In a project's `.nimble` file
+```nim
+requires "leopard >= 0.0.1 & < 0.0.2"
+```
+In a [nimbus-build-system](https://github.com/status-im/nimbus-build-system) project
+```text
+$ git submodule add https://github.com/status-im/nim-leopard.git vendor/nim-leopard
+$ make update
+```
+
+### Submodule
+
+#### Init
+
+[status-im/leopard](https://github.com/status-im/leopard), a fork of [catid/leopard](https://github.com/catid/leopard) (Leopard-RS), is a submodule of nim-leopard.
+
+When nim-leopard is installed with `nimble install leopard`, or as a dependency in a Nimble project, or vendored in a nimbus-build-system project, submodule init is handled automatically.
+
+If the nim-leopard repo is cloned directly, then before running `nimble develop` or `nimble install` in the root of the clone, it's necessary to init the submodule
+```text
+$ git submodule update --init
+```
+
+#### Build
+
+The submodule is automatically built (in the `nimcache` dir) and statically linked during compilation of any Nim module that has `import leopard` or `import leopard/wrapper`.
+
+If the `nimcache` dir is set to a custom value, it must be an absolute path.
+
+For the build to work on Windows, `nimble` or `nim c` must be run from a Bash shell, e.g. Git Bash or an MSYS2 shell, and all needed tools (e.g. `cmake` and `make`) must be available in and suitable for that environment.
+
+##### OpenMP
+
+Leopard-RS' `CMakeLists.txt` checks for [OpenMP](https://en.wikipedia.org/wiki/OpenMP) support. If it is available then it is enabled in the build of `libleopard.a`.
+
+Build toolchains commonly installed on Linux and Windows come with support for OpenMP.
+
+The clang/++ compiler in Apple's Xcode does not support OpenMP, but the one installed with `brew install llvm` does support it, though it's also necessary to `brew install libomp`.
+
+So, on macOS, when running `nimble test` of nim-leopard or compiling a project that imports nim-leopard:
+* If libomp is not installed and Apple's clang is used, no extra flags need to be passed to the Nim compiler. OpenMP support will not be enabled in `libleopard.a`.
+* If libomp is installed and Apple's clang is used, this flag should be passed to `nim c`
+  ```text
+  -d:LeopardCmakeFlags="-DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=off"
+  ```
+* If the intent is to use brew-installed clang + libomp, the shell environment should be modified
+  ```text
+  $ export PATH="$(brew --prefix)/opt/llvm/bin:${PATH}"
+  $ export LDFLAGS="-L$(brew --prefix)/opt/libomp/lib -L$(brew --prefix)/opt/llvm/lib -Wl,-rpath,$(brew --prefix)/opt/llvm/lib"
+  ```
+  and these flags should be passed to `nim c`
+  ```text
+  -d:LeopardCmakeFlags="-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$(brew --prefix)/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix)/opt/llvm/bin/clang++" -d:LeopardExtraCompilerlags="-fopenmp" -d:LeopardExtraLinkerFlags="-fopenmp -L$(brew --prefix)/opt/libomp/lib"
+  ```
+
 ## Usage
 
 ```nim
@@ -20,11 +87,10 @@ var
   data: seq[seq[byte]]
 
 # RS(256,239) :: 239 data symbols, 17 parity symbols
-
-assert RS(256,239).code == 239
+assert RS(256,239).data == 239
 assert RS(256,239).parity == 17
 
-# Choose some N
+# Choose some N for symbolBytes
 N = 1
 # For RS(256,239) fill data such that
 assert data.len == 239
@@ -61,6 +127,10 @@ else:
   # More than 17 holes were poked
   assert recoveredData.error.code == LeopardNeedMoreData
 ```
+
+### OpenMP
+
+When OpenMP is enabled, whether or not parallel processing kicks in depends on the symbol and byte counts. On a local machine with an Intel processor `RS(256,239)` with `symbolBytes == 64` seems to be the lower bound for triggering parallel processing.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ nim-leopard generally follows the upstream `master` branch such that changes the
 
 ## Stability
 
-The API provided by this package is currently marked as experimental. Until it is marked as stable, it may be subject to breaking changes across any version bump.
+This package is currently marked as experimental. Until it is marked as stable, it may be subject to breaking changes across any version bump.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Stability: experimental](https://img.shields.io/badge/stability-experimental-orange.svg)](https://github.com/status-im/nim-leopard#stability)
-[![Tests (GitHub Actions)](https://github.com/status-im/nim-leopard/workflows/Tests/badge.svg?branch=initial_impl)](https://github.com/status-im/nim-leopard/actions?query=workflow%3ATests+branch%3Ainitial_impl)
+[![Tests (GitHub Actions)](https://github.com/status-im/nim-leopard/workflows/Tests/badge.svg?branch=main)](https://github.com/status-im/nim-leopard/actions?query=workflow%3ATests+branch%3Amain)
 
 Nim wrapper for [Leopard-RS](https://github.com/catid/leopard): a fast library for [Reed-Solomon](https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction) erasure correction coding.
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,62 @@ Nim wrapper for [Leopard-RS](https://github.com/catid/leopard): a fast library f
 
 ## Usage
 
-TODO
+```nim
+import leopard
+
+# Initialize Leopard-RS
+leoInit()
+
+var
+  N: Positive
+  data: seq[seq[byte]]
+
+# RS(256,239) :: 239 data symbols, 17 parity symbols
+
+assert RS(256,239).code == 239
+assert RS(256,239).parity == 17
+
+# Choose some N
+N = 1
+# For RS(256,239) fill data such that
+assert data.len == 239
+for i in data: assert i.len == N * 64
+
+# Encode
+let
+  parityData = RS(256,239).encode data
+
+assert parityData.isOk
+assert parityData.get.len == 17
+
+# Poke up to 17 holes total in data and parityData
+var
+  daWithHoles = data
+  paWithHoles = parityData.get
+
+daWithHoles[9]   = @[]
+daWithHoles[53]  = @[]
+daWithHoles[208] = @[]
+# ...
+paWithHoles[1] = @[]
+paWithHoles[4] = @[]
+# ...
+
+# Decode
+let
+  recoveredData = RS(256,239).decode(daWithHoles, paWithHoles, (N * 64).uint)
+
+if recoveredData.isOk:
+  assert recoveredData.get == data
+  assert recoveredData.get != daWithHoles
+else:
+  # More than 17 holes were poked
+  assert recoveredData.error.code == LeopardNeedMoreData
+```
 
 ## Versioning
 
-nim-leopard generally follows the upstream master branch.
+nim-leopard generally follows the upstream `master` branch such that changes there will result in a version bump for this package.
 
 ## Stability
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License: Apache](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Stability: experimental](https://img.shields.io/badge/stability-experimental-orange.svg)](https://github.com/status-im/nim-leopard#stability)
+[![Tests (GitHub Actions)](https://github.com/status-im/nim-leopard/workflows/Tests/badge.svg?branch=initial_impl)](https://github.com/status-im/nim-leopard/actions?query=workflow%3ATests+branch%3Ainitial_impl)
 
 Nim wrapper for [Leopard-RS](https://github.com/catid/leopard): a fast library for [Reed-Solomon](https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction) erasure correction coding.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Stability: experimental](https://img.shields.io/badge/stability-experimental-orange.svg)](https://github.com/status-im/nim-leopard#stability)
+[![Stability: experimental](https://img.shields.io/badge/stability-experimental-orange.svg)](#stability)
 [![Tests (GitHub Actions)](https://github.com/status-im/nim-leopard/workflows/Tests/badge.svg?branch=main)](https://github.com/status-im/nim-leopard/actions?query=workflow%3ATests+branch%3Amain)
 
 Nim wrapper for [Leopard-RS](https://github.com/catid/leopard): a fast library for [Reed-Solomon](https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction) erasure correction coding.
@@ -37,7 +37,7 @@ $ make update
 
 When nim-leopard is installed with `nimble install leopard`, or as a dependency in a Nimble project, or vendored in a nimbus-build-system project, submodule init is handled automatically.
 
-If the nim-leopard repo is cloned directly, then before running `nimble develop` or `nimble install` in the root of the clone, it's necessary to init the submodule
+In a standalone `git clone` of nim-leopard, it's necessary to init the submodule before running `nimble develop` or `nimble install` in the root of the clone
 ```text
 $ git submodule update --init
 ```
@@ -48,7 +48,7 @@ The submodule is automatically built (in the `nimcache` dir) and statically link
 
 If the `nimcache` dir is set to a custom value, it must be an absolute path.
 
-For the build to work on Windows, `nimble` or `nim c` must be run from a Bash shell, e.g. Git Bash or an MSYS2 shell, and all needed tools (e.g. `cmake` and `make`) must be available in and suitable for that environment.
+For the build to work on Windows, `nimble` or `nim c` must be run from a Bash shell, e.g. Git Bash or an MSYS2 shell, and all needed tools (`cmake`, `make`, compiler, etc.) must be available in and suitable for that environment.
 
 ##### OpenMP
 
@@ -56,11 +56,11 @@ Leopard-RS' `CMakeLists.txt` checks for [OpenMP](https://en.wikipedia.org/wiki/O
 
 Build toolchains commonly installed on Linux and Windows come with support for OpenMP.
 
-The clang/++ compiler in Apple's Xcode does not support OpenMP, but the one installed with `brew install llvm` does support it, though it's also necessary to `brew install libomp`.
+The clang compiler that ships with Apple's Xcode does not support OpenMP, but the one installed with `brew install llvm` does support it, though it's also necessary to `brew install libomp`.
 
 So, on macOS, when running `nimble test` of nim-leopard or compiling a project that imports nim-leopard:
-* If libomp is not installed and Apple's clang is used, no extra flags need to be passed to the Nim compiler. OpenMP support will not be enabled in `libleopard.a`.
-* If libomp is installed and Apple's clang is used, this flag should be passed to `nim c`
+* If libomp is not installed and Xcode clang is used, no extra flags need to be passed to the Nim compiler. OpenMP support will not be enabled in `libleopard.a`.
+* If libomp is installed and Xcode clang is used, this flag should be passed to `nim c`
   ```text
   -d:LeopardCmakeFlags="-DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=off"
   ```
@@ -112,8 +112,8 @@ daWithHoles[9]   = @[]
 daWithHoles[53]  = @[]
 daWithHoles[208] = @[]
 # ...
-paWithHoles[1] = @[]
-paWithHoles[4] = @[]
+paWithHoles[1]  = @[]
+paWithHoles[14] = @[]
 # ...
 
 # Decode
@@ -130,15 +130,15 @@ else:
 
 ### OpenMP
 
-When OpenMP is enabled, whether or not parallel processing kicks in depends on the symbol and byte counts. On a local machine with an Intel processor `RS(256,239)` with `symbolBytes == 64` seems to be the lower bound for triggering parallel processing.
+When OpenMP is enabled, whether or not parallel processing kicks in depends on the symbol and byte counts. `RS(256,239)` with `symbolBytes == 64` seems to be the lower bound for triggering parallel processing on a local machine with a 64-bit Intel processor.
 
 ## Versioning
 
-nim-leopard generally follows the upstream `master` branch such that changes there will result in a version bump for this package.
+nim-leopard generally follows the upstream `master` branch of [status-im/leopard](https://github.com/status-im/leopard) such that changes there will result in a version bump for this project.
 
 ## Stability
 
-This package is currently marked as experimental. Until it is marked as stable, it may be subject to breaking changes across any version bump.
+nim-leopard is currently marked as experimental and may be subject to breaking changes across any version bump until it is marked as stable.
 
 ## License
 

--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,2 @@
+--threads:on
+--tlsEmulation:off

--- a/leopard.nim
+++ b/leopard.nim
@@ -169,7 +169,7 @@ proc encode*(code: ReedSolomonCode, data: Data):
         msg: LeopardInconsistentSizeMsg)
 
     enData[i] = allocAligned(symbolBytes, LEO_ALIGN_BYTES)
-    moveMem(enData[i], addr data[i][0], symbolBytes)
+    copyMem(enData[i], addr data[i][0], symbolBytes)
 
   let
     workCount = leoEncodeWorkCount(code.data.cuint, code.parity.cuint)
@@ -207,7 +207,7 @@ proc encode*(code: ReedSolomonCode, data: Data):
   newSeq(parityData, code.parity)
   for i in 0..<code.parity:
     newSeq(parityData[i], symbolBytes)
-    moveMem(addr parityData[i][0], workData[i], symbolBytes)
+    copyMem(addr parityData[i][0], workData[i], symbolBytes)
 
   for i in 0..<code.data: freeAligned enData[i]
   for i in 0..<workCount: freeAligned workData[i]
@@ -255,7 +255,7 @@ proc decode*(code: ReedSolomonCode, data: Data, parityData: ParityData,
           msg: LeopardInconsistentSizeMsg)
 
       deData[i] = allocAligned(symbolBytes.int, LEO_ALIGN_BYTES)
-      moveMem(deData[i], addr data[i][0], symbolBytes)
+      copyMem(deData[i], addr data[i][0], symbolBytes)
 
     else:
       holes.add i.int
@@ -276,7 +276,7 @@ proc decode*(code: ReedSolomonCode, data: Data, parityData: ParityData,
           msg: LeopardInconsistentSizeMsg)
 
       paData[i] = allocAligned(symbolBytes.int, LEO_ALIGN_BYTES)
-      moveMem(paData[i], addr parityData[i][0], symbolBytes)
+      copyMem(paData[i], addr parityData[i][0], symbolBytes)
 
   let
     workCount = leoDecodeWorkCount(code.data.cuint, code.parity.cuint)
@@ -317,7 +317,7 @@ proc decode*(code: ReedSolomonCode, data: Data, parityData: ParityData,
   newSeq(recoveredData, workCount)
   for i in 0..<workCount:
     newSeq(recoveredData[i], symbolBytes)
-    moveMem(addr recoveredData[i][0], workData[i], symbolBytes)
+    copyMem(addr recoveredData[i][0], workData[i], symbolBytes)
 
   for i in holes:
     data[i] = recoveredData[i]

--- a/leopard.nim
+++ b/leopard.nim
@@ -1,0 +1,307 @@
+import pkg/stew/ptrops
+import pkg/stew/results
+import pkg/upraises
+
+import ./leopard/wrapper
+
+export results
+
+push: {.upraises: [].}
+
+const
+  LeopardBadCodeMsg = "Bad RS code"
+  LeopardInconsistentSizeMsg =
+    "Buffer sizes must all be the same multiple of 64 bytes"
+  LeopardNeedLessDataMsg = "Too much recovery data received"
+  LeopardNotEnoughDataMsg = "Buffer counts are too low"
+
+  MinBufferSize* = 64.uint
+
+type
+  Data* = seq[seq[byte]]
+
+  LeopardDefect* = object of Defect
+
+  # It should not be necessary to redefine LeopardResult, but if that's not
+  # done here then defining LeopardError as `object of CatchableError` will
+  # cause a mystery crash at compile-time (symbol not found). Can workaround by
+  # defining as just `object`, but then when trying to work with LeopardResult
+  # errors in e.g. tests/test_leopard.nim the same mystery crash happens at
+  # compile-time. The problem may be related to use of importcpp in
+  # leopard/wrapper.nim, so it could be a compiler bug. By redefining
+  # LeopardResult in this module (and casting wrapper.LeopardResult values) the
+  # the problem is avoided.
+  LeopardResult* = enum
+    LeopardNotEnoughData    = -11.cint # Buffer counts are too low
+    LeopardNeedLessData     = -10.cint # Too much recovery data received
+    LeopardInconsistentSize =  -9.cint # Buffer sizes must all be the same multiple of 64 bytes
+    LeopardBadCode          =  -8.cint # Bad RS code
+    LeopardCallInitialize   = wrapper.LeopardCallInitialize
+    LeopardPlatform         = wrapper.LeopardPlatform
+    LeopardInvalidInput     = wrapper.LeopardInvalidInput
+    LeopardInvalidCounts    = wrapper.LeopardInvalidCounts
+    LeopardInvalidSize      = wrapper.LeopardInvalidSize
+    LeopardTooMuchData      = wrapper.LeopardTooMuchData
+    LeopardNeedMoreData     = wrapper.LeopardNeedMoreData
+    LeopardSuccess          = wrapper.LeopardSuccess
+
+  LeopardError* = object of CatchableError
+    code*: LeopardResult
+
+  ParityData* = Data
+
+  ReedSolomonCode* = tuple[codeword, data, parity: uint] # symbol counts
+
+# https://github.com/catid/leopard/issues/12
+# https://www.cs.cmu.edu/~guyb/realworld/reedsolomon/reed_solomon_codes.html
+#
+# RS(255,239)
+# ---------------------------------
+# codeword symbols = 255
+# data symbols     = 239
+# parity symbols   = 255 - 239 = 16
+
+proc RS*(codeword, data: Positive): ReedSolomonCode =
+  var
+    parity = codeword - data
+
+  if parity <= 0: parity = 0
+  (codeword: codeword.uint, data: data.uint, parity: parity.uint)
+
+when (NimMajor, NimMinor, NimPatch) < (1, 4, 0):
+  const
+    header = "<stdlib.h>"
+
+  proc c_malloc(size: csize_t): pointer {.importc: "malloc", header: header.}
+  proc c_free(p: pointer) {.importc: "free", header: header.}
+
+proc SIMDSafeAllocate(size: int): pointer {.inline.}  =
+  var
+    data =
+      when (NimMajor, NimMinor, NimPatch) < (1, 4, 0):
+        c_malloc(LEO_ALIGN_BYTES + size.uint)
+      else:
+        allocShared(LEO_ALIGN_BYTES + size.uint)
+
+    doffset = cast[uint](data) mod LEO_ALIGN_BYTES
+
+  data = offset(data, (LEO_ALIGN_BYTES + doffset).int)
+
+  var
+    offsetPtr = cast[pointer](cast[uint](data) - 1)
+
+  moveMem(offsetPtr, addr doffset, sizeof(doffset))
+  data
+
+proc SIMDSafeFree(data: pointer) {.inline.} =
+  var
+    data = data
+
+  if not data.isNil:
+    let
+      offset = cast[uint](data) - 1
+
+    if offset >= LEO_ALIGN_BYTES: return
+
+    data = cast[pointer](cast[uint](data) - (LEO_ALIGN_BYTES - offset))
+
+    when (NimMajor, NimMinor, NimPatch) < (1, 4, 0):
+      c_free data
+    else:
+      deallocShared data
+
+proc leoInit*() =
+  if wrapper.leoInit() != 0:
+    raise (ref LeopardDefect)(msg: "Leopard-RS failed to initialize")
+
+proc encode*(code: ReedSolomonCode, data: Data):
+    Result[ParityData, LeopardError] =
+  if code.parity < 1 or code.parity > code.data:
+    return err LeopardError(code: LeopardBadCode, msg: LeopardBadCodeMsg)
+
+  var
+    data = data
+
+  let
+    symbolBytes = data[0].len
+
+  if data.len < code.data.int:
+    return err LeopardError(code: LeopardNotEnoughData,
+      msg: LeopardNotEnoughDataMsg)
+
+  elif data.len > code.data.int:
+    return err LeopardError(code: LeopardTooMuchData,
+      msg: $leoResultString(wrapper.LeopardTooMuchData))
+
+  if symbolBytes < MinBufferSize.int or symbolBytes mod MinBufferSize.int != 0:
+    return err LeopardError(code: LeopardInvalidSize,
+      msg: $leoResultString(wrapper.LeopardInvalidSize))
+
+  var
+    enData = newSeq[pointer](code.data)
+
+  for i in 0..<code.data:
+    if data[i].len != symbolBytes:
+      for i in 0..<code.data: SIMDSafeFree enData[i]
+      return err LeopardError(code: LeopardInconsistentSize,
+        msg: LeopardInconsistentSizeMsg)
+
+    enData[i] = SIMDSafeAllocate symbolBytes
+    moveMem(enData[i], addr data[i][0], symbolBytes)
+
+  let
+    workCount = leoEncodeWorkCount(code.data.cuint, code.parity.cuint)
+
+  if workCount == 0:
+    for i in 0..<code.data: SIMDSafeFree enData[i]
+    return err LeopardError(code: LeopardInvalidInput,
+      msg: $leoResultString(wrapper.LeopardInvalidInput))
+
+  var
+    workData = newSeq[pointer](workCount)
+
+  for i in 0..<workCount:
+    workData[i] = SIMDSafeAllocate symbolBytes
+
+  let
+    encodeRes = leoEncode(
+      symbolBytes.uint64,
+      code.data.cuint,
+      code.parity.cuint,
+      workCount,
+      addr enData[0],
+      addr workData[0]
+    )
+
+  if encodeRes != wrapper.LeopardSuccess:
+    for i in 0..<code.data: SIMDSafeFree enData[i]
+    for i in 0..<workCount: SIMDSafeFree workData[i]
+    return err LeopardError(code: cast[LeopardResult](encodeRes),
+      msg: $leoResultString(encodeRes))
+
+  var
+    parityData: ParityData
+
+  newSeq(parityData, code.parity)
+  for i in 0..<code.parity:
+    newSeq(parityData[i], symbolBytes)
+    moveMem(addr parityData[i][0], workData[i], symbolBytes)
+
+  for i in 0..<code.data: SIMDSafeFree enData[i]
+  for i in 0..<workCount: SIMDSafeFree workData[i]
+
+  ok parityData
+
+proc decode*(code: ReedSolomonCode, data: Data, parityData: ParityData,
+    symbolBytes: uint): Result[Data, LeopardError] =
+  if code.parity < 1 or code.parity > code.data:
+    return err LeopardError(code: LeopardBadCode, msg: LeopardBadCodeMsg)
+
+  var
+    data = data
+    parityData = parityData
+    holes: seq[int]
+
+  if data.len < code.data.int:
+    return err LeopardError(code: LeopardNotEnoughData,
+      msg: LeopardNotEnoughDataMsg)
+
+  elif data.len > code.data.int:
+    return err LeopardError(code: LeopardTooMuchData,
+      msg: $leoResultString(wrapper.LeopardTooMuchData))
+
+  if parityData.len < code.parity.int:
+    return err LeopardError(code: LeopardNeedMoreData,
+      msg: $leoResultString(wrapper.LeopardNeedMoreData))
+
+  elif parityData.len > code.parity.int:
+    return err LeopardError(code: LeopardNeedLessData,
+      msg: LeopardNeedLessDataMsg)
+
+  if symbolBytes < MinBufferSize or symbolBytes mod MinBufferSize != 0:
+    return err LeopardError(code: LeopardInvalidSize,
+      msg: $leoResultString(wrapper.LeopardInvalidSize))
+
+  var
+    deData = newSeq[pointer](code.data)
+
+  for i in 0..<code.data:
+    if data[i].len != 0:
+      if data[i].len != symbolBytes.int:
+        for i in 0..<code.data: SIMDSafeFree deData[i]
+        return err LeopardError(code: LeopardInconsistentSize,
+          msg: LeopardInconsistentSizeMsg)
+
+      deData[i] = SIMDSafeAllocate symbolBytes.int
+      moveMem(deData[i], addr data[i][0], symbolBytes)
+
+    else:
+      holes.add i.int
+
+  if holes.len == 0:
+    for i in 0..<code.data: SIMDSafeFree deData[i]
+    return ok data
+
+  var
+    paData = newSeq[pointer](code.parity)
+
+  for i in 0..<code.parity:
+    if parityData[i].len != 0:
+      if parityData[i].len != symbolBytes.int:
+        for i in 0..<code.data: SIMDSafeFree deData[i]
+        for i in 0..<code.parity: SIMDSafeFree paData[i]
+        return err LeopardError(code: LeopardInconsistentSize,
+          msg: LeopardInconsistentSizeMsg)
+
+      paData[i] = SIMDSafeAllocate symbolBytes.int
+      moveMem(paData[i], addr parityData[i][0], symbolBytes)
+
+  let
+    workCount = leoDecodeWorkCount(code.data.cuint, code.parity.cuint)
+
+  if workCount == 0:
+    for i in 0..<code.data: SIMDSafeFree deData[i]
+    for i in 0..<code.parity: SIMDSafeFree paData[i]
+    return err LeopardError(code: LeopardInvalidInput,
+      msg: $leoResultString(wrapper.LeopardInvalidInput))
+
+  var
+    workData = newSeq[pointer](workCount)
+
+  for i in 0..<workCount:
+    workData[i] = SIMDSafeAllocate symbolBytes.int
+
+  let
+    decodeRes = leoDecode(
+      symbolBytes.uint64,
+      code.data.cuint,
+      code.parity.cuint,
+      workCount,
+      addr deData[0],
+      addr paData[0],
+      addr workData[0]
+    )
+
+  if decodeRes != wrapper.LeopardSuccess:
+    for i in 0..<code.data: SIMDSafeFree deData[i]
+    for i in 0..<code.parity: SIMDSafeFree paData[i]
+    for i in 0..<workCount: SIMDSafeFree workData[i]
+    return err LeopardError(code: cast[LeopardResult](decodeRes),
+      msg: $leoResultString(decodeRes))
+
+  var
+    recoveredData: Data
+
+  newSeq(recoveredData, workCount)
+  for i in 0..<workCount:
+    newSeq(recoveredData[i], symbolBytes)
+    moveMem(addr recoveredData[i][0], workData[i], symbolBytes)
+
+  for i in holes:
+    data[i] = recoveredData[i]
+
+  for i in 0..<code.data: SIMDSafeFree deData[i]
+  for i in 0..<code.parity: SIMDSafeFree paData[i]
+  for i in 0..<workCount: SIMDSafeFree workData[i]
+
+  ok data

--- a/leopard.nim
+++ b/leopard.nim
@@ -47,8 +47,15 @@ type
     LeopardNeedMoreData     = wrapper.LeopardNeedMoreData
     LeopardSuccess          = wrapper.LeopardSuccess
 
-  LeopardError* = object of CatchableError
+  # Regardless of comment above, if LeopardError is `object of CatchableError`
+  # there seems to be a weird edge case, possibly owing to the LeopardResult
+  # enum starting with a negative number, whereby there is a compile-time error
+  # on Linux and Windows (but not macOS) re: stew/results in the context of a
+  # nimbus-build-system project; that error is not encountered in a
+  # choosenim/nimble setup using Nim 1.2, 1.4, or 1.6.
+  LeopardError* = object # of CatchableError
     code*: LeopardResult
+    msg*: string
 
   ParityData* = Data
 

--- a/leopard.nim
+++ b/leopard.nim
@@ -1,3 +1,4 @@
+import pkg/stew/ptrops
 import pkg/stew/results
 import pkg/upraises
 
@@ -169,7 +170,8 @@ proc encode*(code: ReedSolomonCode, data: Data):
         msg: LeopardInconsistentSizeMsg)
 
     enData[i] = allocAligned(symbolBytes, LEO_ALIGN_BYTES)
-    copyMem(enData[i], addr data[i][0], symbolBytes)
+    for j in 0..<symbolBytes:
+      copyMem(enData[i].offset j, addr data[i][j], 1)
 
   let
     workCount = leoEncodeWorkCount(code.data.cuint, code.parity.cuint)
@@ -207,7 +209,8 @@ proc encode*(code: ReedSolomonCode, data: Data):
   newSeq(parityData, code.parity)
   for i in 0..<code.parity:
     newSeq(parityData[i], symbolBytes)
-    copyMem(addr parityData[i][0], workData[i], symbolBytes)
+    for j in 0..<symbolBytes:
+      copyMem(addr parityData[i][j], workData[i].offset j, 1)
 
   for i in 0..<code.data: freeAligned enData[i]
   for i in 0..<workCount: freeAligned workData[i]
@@ -255,7 +258,8 @@ proc decode*(code: ReedSolomonCode, data: Data, parityData: ParityData,
           msg: LeopardInconsistentSizeMsg)
 
       deData[i] = allocAligned(symbolBytes.int, LEO_ALIGN_BYTES)
-      copyMem(deData[i], addr data[i][0], symbolBytes)
+      for j in 0..<symbolBytes.int:
+        copyMem(deData[i].offset j, addr data[i][j], 1)
 
     else:
       holes.add i.int
@@ -276,7 +280,8 @@ proc decode*(code: ReedSolomonCode, data: Data, parityData: ParityData,
           msg: LeopardInconsistentSizeMsg)
 
       paData[i] = allocAligned(symbolBytes.int, LEO_ALIGN_BYTES)
-      copyMem(paData[i], addr parityData[i][0], symbolBytes)
+      for j in 0..<symbolBytes.int:
+        copyMem(paData[i].offset j, addr parityData[i][j], 1)
 
   let
     workCount = leoDecodeWorkCount(code.data.cuint, code.parity.cuint)
@@ -317,7 +322,8 @@ proc decode*(code: ReedSolomonCode, data: Data, parityData: ParityData,
   newSeq(recoveredData, workCount)
   for i in 0..<workCount:
     newSeq(recoveredData[i], symbolBytes)
-    copyMem(addr recoveredData[i][0], workData[i], symbolBytes)
+    for j in 0..<symbolBytes.int:
+      copyMem(addr recoveredData[i][j], workData[i].offset j, 1)
 
   for i in holes:
     data[i] = recoveredData[i]

--- a/leopard.nim
+++ b/leopard.nim
@@ -165,7 +165,7 @@ proc encode*(code: ReedSolomonCode, data: Data):
 
   for i in 0..<code.data:
     if data[i].len != symbolBytes:
-      for i in 0..<code.data: freeAligned enData[i]
+      for j in 0..<(i - 1): freeAligned enData[j]
       return err LeopardError(code: LeopardInconsistentSize,
         msg: LeopardInconsistentSizeMsg)
 
@@ -253,7 +253,7 @@ proc decode*(code: ReedSolomonCode, data: Data, parityData: ParityData,
   for i in 0..<code.data:
     if data[i].len != 0:
       if data[i].len != symbolBytes.int:
-        for i in 0..<code.data: freeAligned deData[i]
+        for j in 0..<(i - 1): freeAligned deData[j]
         return err LeopardError(code: LeopardInconsistentSize,
           msg: LeopardInconsistentSizeMsg)
 
@@ -274,8 +274,8 @@ proc decode*(code: ReedSolomonCode, data: Data, parityData: ParityData,
   for i in 0..<code.parity:
     if parityData[i].len != 0:
       if parityData[i].len != symbolBytes.int:
-        for i in 0..<code.data: freeAligned deData[i]
-        for i in 0..<code.parity: freeAligned paData[i]
+        for j in 0..<code.data: freeAligned deData[j]
+        for j in 0..<(i - 1): freeAligned paData[j]
         return err LeopardError(code: LeopardInconsistentSize,
           msg: LeopardInconsistentSizeMsg)
 

--- a/leopard.nimble
+++ b/leopard.nimble
@@ -5,7 +5,9 @@ version       = "0.0.1"
 author        = "Status Research & Development GmbH"
 description   = "A wrapper for Leopard-RS"
 license       = "Apache License 2.0 or MIT"
+installDirs   = @["vendor"]
 
 requires "nim >= 1.2.0",
-         "stew#head",
-         "unittest2"
+         "stew",
+         "unittest2",
+         "upraises >= 0.1.0 & < 0.2.0"

--- a/leopard/wrapper.nim
+++ b/leopard/wrapper.nim
@@ -1,0 +1,293 @@
+## Copyright (c) 2017 Christopher A. Taylor.  All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+## * Redistributions of source code must retain the above copyright notice,
+##   this list of conditions and the following disclaimer.
+## * Redistributions in binary form must reproduce the above copyright notice,
+##   this list of conditions and the following disclaimer in the documentation
+##   and/or other materials provided with the distribution.
+## * Neither the name of Leopard-RS nor the names of its contributors may be
+##   used to endorse or promote products derived from this software without
+##   specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+## IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+## ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+## LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+## CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+## SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+## INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+## CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+## POSSIBILITY OF SUCH DAMAGE.
+
+
+## Leopard-RS
+## MDS Reed-Solomon Erasure Correction Codes for Large Data in C
+##
+## Algorithms are described in LeopardCommon.h
+##
+##
+## Inspired by discussion with:
+##
+## Sian-Jhen Lin <sjhenglin@gmail.com> : Author of {1} {3}, basis for Leopard
+## Bulat Ziganshin <bulat.ziganshin@gmail.com> : Author of FastECC
+## Yutaka Sawada <tenfon@outlook.jp> : Author of MultiPar
+##
+##
+## References:
+##
+## {1} S.-J. Lin, T. Y. Al-Naffouri, Y. S. Han, and W.-H. Chung,
+## "Novel Polynomial Basis with Fast Fourier Transform
+## and Its Application to Reed-Solomon Erasure Codes"
+## IEEE Trans. on Information Theory, pp. 6284-6299, November, 2016.
+##
+## {2} D. G. Cantor, "On arithmetical algorithms over finite fields",
+## Journal of Combinatorial Theory, Series A, vol. 50, no. 2, pp. 285-300, 1989.
+##
+## {3} Sian-Jheng Lin, Wei-Ho Chung, "An Efficient (n, k) Information
+## Dispersal Algorithm for High Code Rate System over Fermat Fields,"
+## IEEE Commun. Lett., vol.16, no.12, pp. 2036-2039, Dec. 2012.
+##
+## {4} Plank, J. S., Greenan, K. M., Miller, E. L., "Screaming fast Galois Field
+## arithmetic using Intel SIMD instructions."  In: FAST-2013: 11th Usenix
+## Conference on File and Storage Technologies, San Jose, 2013
+
+
+import upraises
+push: {.upraises: [].}
+
+
+## -----------------------------------------------------------------------------
+## Build configuration
+
+import std/compilesettings
+import std/os
+import std/strutils
+
+const
+  LeopardCmakeFlags {.strdefine.} =
+    when defined(macosx):
+      "-DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=off"
+    elif defined(windows):
+      "-G\"MSYS Makefiles\" -DCMAKE_BUILD_TYPE=Release"
+    else:
+      "-DCMAKE_BUILD_TYPE=Release"
+
+  LeopardDir {.strdefine.} =
+    joinPath(currentSourcePath.parentDir.parentDir, "vendor", "leopard")
+
+  buildDir = joinPath(querySetting(nimcacheDir), "vendor_leopard")
+
+  LeopardHeader {.strdefine.} = "leopard.h"
+
+  LeopardLib {.strdefine.} = joinPath(buildDir, "liblibleopard.a")
+
+  LeopardCompilerFlags {.strdefine.} =
+    when defined(macosx):
+      "-I" & LeopardDir
+    else:
+      "-I" & LeopardDir & " -fopenmp"
+
+  LeopardLinkerFlags {.strdefine.} =
+    when defined(macosx):
+      LeopardLib
+    else:
+      LeopardLib & " -fopenmp"
+
+  LeopardExtraCompilerFlags {.strdefine.} = ""
+
+  LeopardExtraLinkerFlags {.strdefine.} = ""
+
+static:
+  if defined(windows):
+    func pathUnix2Win(path: string): string =
+      gorge("cygpath -w " & path.strip).strip
+
+    func pathWin2Unix(path: string): string =
+      gorge("cygpath " & path.strip).strip
+
+    proc bash(cmd: varargs[string]): string =
+      gorge(gorge("which bash").pathUnix2Win & " -c '" & cmd.join(" ") & "'")
+
+    proc bashEx(cmd: varargs[string]): tuple[output: string, exitCode: int] =
+      gorgeEx(gorge("which bash").pathUnix2Win & " -c '" & cmd.join(" ") & "'")
+
+    let
+      buildDirUnix = buildDir.pathWin2Unix
+      leopardDirUnix = LeopardDir.pathWin2Unix
+    if defined(LeopardRebuild): discard bash("rm -rf", buildDirUnix)
+    if (bashEx("ls", LeopardLib.pathWin2Unix)).exitCode != 0:
+      discard bash("mkdir -p", buildDirUnix)
+      let cmd =
+        @["cd", buildDirUnix, "&& cmake", leopardDirUnix, LeopardCmakeFlags,
+          "&& make"]
+      echo "\nBuilding Leopard-RS: " & cmd.join(" ")
+      let (output, exitCode) = bashEx cmd
+      echo output
+      if exitCode != 0:
+        discard bash("rm -rf", buildDirUnix)
+        raise (ref Defect)(msg: "Failed to build Leopard-RS")
+  else:
+    if defined(LeopardRebuild): discard gorge "rm -rf " & buildDir
+    if gorgeEx("ls " & LeopardLib).exitCode != 0:
+      discard gorge "mkdir -p " & buildDir
+      let cmd =
+        "cd " & buildDir & " && cmake " & LeopardDir & " " & LeopardCmakeFlags &
+        " && make"
+      echo "\nBuilding Leopard-RS: " & cmd
+      let (output, exitCode) = gorgeEx cmd
+      echo output
+      if exitCode != 0:
+        discard gorge "rm -rf " & buildDir
+        raise (ref Defect)(msg: "Failed to build Leopard-RS")
+
+{.passC: LeopardCompilerFlags & " " & LeopardExtraCompilerFlags.}
+{.passL: LeopardLinkerFlags & " " & LeopardExtraLinkerFlags.}
+
+{.pragma: leo, cdecl, header: LeopardHeader.}
+
+
+## -----------------------------------------------------------------------------
+## Library version
+
+var LEO_VERSION* {.header: LeopardHeader, importc.}: int
+
+
+## -----------------------------------------------------------------------------
+## Platform/Architecture
+
+# maybe should detect AVX2 and set to 32 if detected, 16 otherwise:
+# https://github.com/catid/leopard/blob/master/LeopardCommon.h#L247-L253
+# https://github.com/mratsim/Arraymancer/blob/master/src/arraymancer/laser/cpuinfo_x86.nim#L220
+const LEO_ALIGN_BYTES* = 16
+
+
+## -----------------------------------------------------------------------------
+## Initialization API
+
+## leoInit()
+##
+## Perform static initialization for the library, verifying that the platform
+## is supported.
+##
+## Returns 0 on success and other values on failure.
+
+proc leoInit*(): cint {.leo, importcpp: "leo_init".}
+
+
+## -----------------------------------------------------------------------------
+## Shared Constants / Datatypes
+
+## Results
+type
+  LeopardResult* = enum
+    LeopardCallInitialize = -7.cint ## Call leoInit() first
+    LeopardPlatform       = -6.cint ## Platform is unsupported
+    LeopardInvalidInput   = -5.cint ## A function parameter was invalid
+    LeopardInvalidCounts  = -4.cint ## Invalid counts provided
+    LeopardInvalidSize    = -3.cint ## Buffer size must be multiple of 64 bytes
+    LeopardTooMuchData    = -2.cint ## Buffer counts are too high
+    LeopardNeedMoreData   = -1.cint ## Not enough recovery data received
+    LeopardSuccess        =  0.cint ## Operation succeeded
+
+## Convert Leopard result to string
+func leoResultString*(res: LeopardResult): cstring
+  {.leo, importc: "leo_result_string".}
+
+
+## -----------------------------------------------------------------------------
+## Encoder API
+
+## leoEncodeWorkCount()
+##
+## Calculate the number of work data buffers to provide to leoEncode().
+##
+## The sum of originalCount + recoveryCount must not exceed 65536.
+##
+## Returns the workCount value to pass into leoEncode().
+## Returns 0 on invalid input.
+
+func leoEncodeWorkCount*(originalCount, recoveryCount: cuint): cuint
+  {.leo, importc: "leo_encode_work_count".}
+
+## leoEncode()
+##
+## Generate recovery data.
+##
+## bufferBytes:   Number of bytes in each data buffer.
+## originalCount: Number of original data buffers provided.
+## recoveryCount: Number of desired recovery data buffers.
+## workCount:     Number of work data buffers, from leoEncodeWorkCount().
+## originalData:  Array of pointers to original data buffers.
+## workData:      Array of pointers to work data buffers.
+##
+## The sum of originalCount + recoveryCount must not exceed 65536.
+## The recoveryCount <= originalCount.
+##
+## The value of bufferBytes must be a multiple of 64.
+## Each buffer should have the same number of bytes.
+## Even the last piece must be rounded up to the block size.
+##
+## Returns LeopardSuccess on success.
+## The first set of recoveryCount buffers in workData will be the result.
+## Returns other values on errors.
+
+proc leoEncode*(
+  bufferBytes: uint64,   ## Number of bytes in each data buffer
+  originalCount: cuint,  ## Number of originalData[] buffer pointers
+  recoveryCount: cuint,  ## Number of recovery data buffer pointers
+                         ## (readable post-call from start of workData[])
+  workCount: cuint,      ## Number of workData[] buffer pointers
+  originalData: pointer, ## Array of pointers to original data buffers
+  workData: pointer,     ## Array of pointers to work data buffers
+): LeopardResult {.leo, importc: "leo_encode".}
+
+
+## -----------------------------------------------------------------------------
+## Decoder API
+
+## leoDecodeWorkCount()
+##
+## Calculate the number of work data buffers to provide to leoDecode().
+##
+## The sum of originalCount + recoveryCount must not exceed 65536.
+##
+## Returns the workCount value to pass into leoDecode().
+## Returns 0 on invalid input.
+
+func leoDecodeWorkCount*(originalCount, recoveryCount: cuint): cuint
+  {.leo, importc: "leo_decode_work_count".}
+
+## leoDecode()
+##
+## Decode original data from recovery data.
+##
+## bufferBytes:   Number of bytes in each data buffer.
+## originalCount: Number of original data buffers provided.
+## recoveryCount: Number of recovery data buffers provided.
+## workCount:     Number of work data buffers, from leoDecodeWorkCount().
+## originalData:  Array of pointers to original data buffers.
+## recoveryData:  Array of pointers to recovery data buffers.
+## workData:      Array of pointers to work data buffers.
+##
+## Lost original/recovery data should be set to NULL.
+##
+## The sum of recoveryCount + the number of non-NULL original data must be at
+## least originalCount in order to perform recovery.
+##
+## Returns LeopardSuccess on success.
+## Returns other values on errors.
+
+proc leoDecode*(
+  bufferBytes: uint64,   ## Number of bytes in each data buffer
+  originalCount: cuint,  ## Number of originalData[] buffer pointers
+  recoveryCount: cuint,  ## Number of recoveryData[] buffer pointers
+  workCount: cuint,      ## Number of workData[] buffer pointers
+  originalData: pointer, ## Array of pointers to original data buffers
+  recoveryData: pointer, ## Array of pointers to recovery data buffers
+  workData: pointer,     ## Array of pointers to work data buffers
+): LeopardResult {.leo, importc: "leo_decode".}

--- a/leopard/wrapper.nim
+++ b/leopard/wrapper.nim
@@ -237,13 +237,13 @@ func leoEncodeWorkCount*(originalCount, recoveryCount: cuint): cuint
 ## Returns other values on errors.
 
 proc leoEncode*(
-  bufferBytes: uint64,   ## Number of bytes in each data buffer
-  originalCount: cuint,  ## Number of originalData[] buffer pointers
-  recoveryCount: cuint,  ## Number of recovery data buffer pointers
-                         ## (readable post-call from start of workData[])
-  workCount: cuint,      ## Number of workData[] buffer pointers
-  originalData: pointer, ## Array of pointers to original data buffers
-  workData: pointer,     ## Array of pointers to work data buffers
+  bufferBytes: uint64,       ## Number of bytes in each data buffer
+  originalCount: cuint,      ## Number of originalData[] buffer pointers
+  recoveryCount: cuint,      ## Number of recovery data buffer pointers
+                             ## (readable post-call from start of workData[])
+  workCount: cuint,          ## Number of workData[] buffer pointers
+  originalData: ptr pointer, ## Array of pointers to original data buffers
+  workData: ptr pointer,     ## Array of pointers to work data buffers
 ): LeopardResult {.leo, importc: "leo_encode".}
 
 
@@ -283,11 +283,11 @@ func leoDecodeWorkCount*(originalCount, recoveryCount: cuint): cuint
 ## Returns other values on errors.
 
 proc leoDecode*(
-  bufferBytes: uint64,   ## Number of bytes in each data buffer
-  originalCount: cuint,  ## Number of originalData[] buffer pointers
-  recoveryCount: cuint,  ## Number of recoveryData[] buffer pointers
-  workCount: cuint,      ## Number of workData[] buffer pointers
-  originalData: pointer, ## Array of pointers to original data buffers
-  recoveryData: pointer, ## Array of pointers to recovery data buffers
-  workData: pointer,     ## Array of pointers to work data buffers
+  bufferBytes: uint64,       ## Number of bytes in each data buffer
+  originalCount: cuint,      ## Number of originalData[] buffer pointers
+  recoveryCount: cuint,      ## Number of recoveryData[] buffer pointers
+  workCount: cuint,          ## Number of workData[] buffer pointers
+  originalData: ptr pointer, ## Array of pointers to original data buffers
+  recoveryData: ptr pointer, ## Array of pointers to recovery data buffers
+  workData: ptr pointer,     ## Array of pointers to work data buffers
 ): LeopardResult {.leo, importc: "leo_decode".}

--- a/tests/test_leopard.nim
+++ b/tests/test_leopard.nim
@@ -19,6 +19,33 @@ proc genData(outerLen, innerLen: uint): Data =
 var
   initialized = false
 
+suite "Helpers":
+  test "isValid should return false if RS code is nonsensical or is invalid per Leopard-RS":
+    var
+      rsCode = (codeword: 8.uint, data: 5.uint, parity: 1.uint)
+
+    check: not rsCode.isValid
+
+    rsCode = RS(110,10)
+
+    check: not rsCode.isValid
+
+    rsCode = RS(1,1)
+
+    check: not rsCode.isValid
+
+    rsCode = (codeword: 2.uint, data: 0.uint, parity: 2.uint)
+
+    check: not rsCode.isValid
+
+    rsCode = RS(2,2)
+
+    check: not rsCode.isValid
+
+    rsCode = RS(65537,65409)
+
+    check: not rsCode.isValid
+
 suite "Initialization":
   test "encode and decode should fail if Leopard-RS is not initialized":
     let
@@ -53,7 +80,7 @@ suite "Initialization":
     check: initialized
 
 suite "Encoder":
-  test "should fail if RS code is nonsensical or is so per Leopard-RS":
+  test "should fail if RS code is nonsensical or is invalid per Leopard-RS":
     check: initialized
     if not initialized: return
 
@@ -61,25 +88,9 @@ suite "Encoder":
       symbolBytes = MinBufferSize
 
     var
-      rsCode = RS(5,5)
+      rsCode = RS(110,10)
       data = genData(rsCode.data, symbolBytes)
       encodeRes = rsCode.encode data
-
-    check: encodeRes.isErr
-    if encodeRes.isErr:
-      check: encodeRes.error.code == LeopardBadCode
-
-    rsCode = RS(5,10)
-    data = genData(rsCode.data, symbolBytes)
-    encodeRes = rsCode.encode data
-
-    check: encodeRes.isErr
-    if encodeRes.isErr:
-      check: encodeRes.error.code == LeopardBadCode
-
-    rsCode = RS(110,10)
-    data = genData(rsCode.data, symbolBytes)
-    encodeRes = rsCode.encode data
 
     check: encodeRes.isErr
     if encodeRes.isErr:
@@ -185,7 +196,7 @@ suite "Encoder":
     check: encodeRes.isOk
 
 suite "Decoder":
-  test "should fail if RS code is nonsensical or is so per Leopard-RS":
+  test "should fail if RS code is nonsensical or is invalid per Leopard-RS":
     check: initialized
     if not initialized: return
 
@@ -193,26 +204,10 @@ suite "Decoder":
       symbolBytes = MinBufferSize
 
     var
-      rsCode = RS(5,5)
+      rsCode = RS(110,10)
       data = genData(rsCode.data, symbolBytes)
       parityData: ParityData
       decodeRes = rsCode.decode(data, parityData, symbolBytes)
-
-    check: decodeRes.isErr
-    if decodeRes.isErr:
-      check: decodeRes.error.code == LeopardBadCode
-
-    rsCode = RS(5,10)
-    data = genData(rsCode.data, symbolBytes)
-    decodeRes = rsCode.decode(data, parityData, symbolBytes)
-
-    check: decodeRes.isErr
-    if decodeRes.isErr:
-      check: decodeRes.error.code == LeopardBadCode
-
-    rsCode = RS(110,10)
-    data = genData(rsCode.data, symbolBytes)
-    decodeRes = rsCode.decode(data, parityData, symbolBytes)
 
     check: decodeRes.isErr
     if decodeRes.isErr:

--- a/tests/test_leopard.nim
+++ b/tests/test_leopard.nim
@@ -549,5 +549,3 @@ suite "Encode + Decode":
         echo "encode error message: " & encodeRes.error.msg
 
       inc i
-
-echo ""

--- a/tests/test_leopard.nim
+++ b/tests/test_leopard.nim
@@ -1,0 +1,558 @@
+import std/random
+
+import pkg/leopard
+import pkg/unittest2
+
+randomize()
+
+proc genData(outerLen, innerLen: uint): Data =
+  var
+    data = newSeqOfCap[seq[byte]](outerLen)
+
+  for i in 0..<outerLen.int:
+    data.add newSeqUninitialized[byte](innerLen)
+    for j in 0..<innerLen:
+      data[i][j] = rand(255).byte
+
+  data
+
+var
+  initialized = false
+
+suite "Initialization":
+  test "encode and decode should fail if Leopard-RS is not initialized":
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize
+      parityData = genData(rsCode.parity, symbolBytes)
+
+    var
+      data = genData(rsCode.data, symbolBytes)
+
+    let
+      encodeRes = rsCode.encode data
+
+    # Related to a subtle race re: decode being called with data that has no
+    # holes while Leopard-RS is not initialized, i.e. it would succeed by
+    # simply returning the data without a call to leoDecode.
+    data[0] = @[]
+
+    let
+      decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check:
+      encodeRes.isErr
+      encodeRes.error.code == LeopardCallInitialize
+      decodeRes.isErr
+      decodeRes.error.code == LeopardCallInitialize
+
+  test "initialization should succeed else raise a Defect":
+    leoInit()
+    initialized = true
+
+    check: initialized
+
+suite "Encoder":
+  test "should fail if RS code is nonsensical or is so per Leopard-RS":
+    check: initialized
+    if not initialized: return
+
+    let
+      symbolBytes = MinBufferSize
+
+    var
+      rsCode = RS(5,5)
+      data = genData(rsCode.data, symbolBytes)
+      encodeRes = rsCode.encode data
+
+    check: encodeRes.isErr
+    if encodeRes.isErr:
+      check: encodeRes.error.code == LeopardBadCode
+
+    rsCode = RS(5,10)
+    data = genData(rsCode.data, symbolBytes)
+    encodeRes = rsCode.encode data
+
+    check: encodeRes.isErr
+    if encodeRes.isErr:
+      check: encodeRes.error.code == LeopardBadCode
+
+    rsCode = RS(110,10)
+    data = genData(rsCode.data, symbolBytes)
+    encodeRes = rsCode.encode data
+
+    check: encodeRes.isErr
+    if encodeRes.isErr:
+      check: encodeRes.error.code == LeopardBadCode
+
+  test "should fail if outer length of data does not match the RS code":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize
+      notEnoughData = genData(rsCode.data - 1, symbolBytes)
+      tooMuchData = genData(rsCode.data + 1, symbolBytes)
+      notEnoughEncodeRes = rsCode.encode notEnoughData
+      tooMuchEncodeRes = rsCode.encode tooMuchData
+
+    check:
+        notEnoughEncodeRes.isErr
+        tooMuchEncodeRes.isErr
+    if notEnoughEncodeRes.isErr:
+      check: notEnoughEncodeRes.error.code == LeopardNotEnoughData
+    if tooMuchEncodeRes.isErr:
+      check: tooMuchEncodeRes.error.code == LeopardTooMuchData
+
+  test "should fail if length of data[0] is less than minimum buffer size":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize - 5
+      data = genData(rsCode.data, symbolBytes)
+      encodeRes = rsCode.encode data
+
+    check: encodeRes.isErr
+    if encodeRes.isErr:
+      check: encodeRes.error.code == LeopardInvalidSize
+
+  test "should fail if length of data[0] is not a multiple of minimum buffer size":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize * 2 + 1
+      data = genData(rsCode.data, symbolBytes)
+      encodeRes = rsCode.encode data
+
+    check: encodeRes.isErr
+    if encodeRes.isErr:
+      check: encodeRes.error.code == LeopardInvalidSize
+
+  test "should fail if length of data[0+N] does not equal length of data[0]":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize
+
+    var
+      data = genData(rsCode.data, symbolBytes)
+
+    data[3] = @[1.byte, 2.byte, 3.byte]
+
+    let
+      encodeRes = rsCode.encode data
+
+    check: encodeRes.isErr
+    if encodeRes.isErr:
+      check: encodeRes.error.code == LeopardInconsistentSize
+
+  # With the current setup in leopard.nim it seems it's not possible to call
+  # encode with an RS code that would result in leoEncodeWorkCount being called
+  # with invalid parameters, i.e. that would result in it returning 0, because
+  # a Result error will always be returned before leoEncodeWorkCount is called.
+
+  # test "should fail if RS code parameters yield invalid parameters for leoEncodWorkCount":
+  #   check: initialized
+  #   if not initialized: return
+  #
+  #   let
+  #     rsCode = RS(?,?)
+  #     symbolBytes = MinBufferSize
+  #     data = genData(rsCode.data, symbolBytes)
+  #     encodeRes = rsCode.encode data
+  #
+  #   check: encodeRes.isErr
+  #   if encodeRes.isErr:
+  #     check: encodeRes.error.code == LeopardInvalidInput
+
+  test "should succeed if RS code and data yield valid parameters for leoEncode":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize
+      data = genData(rsCode.data, symbolBytes)
+      encodeRes = rsCode.encode data
+
+    check: encodeRes.isOk
+
+suite "Decoder":
+  test "should fail if RS code is nonsensical or is so per Leopard-RS":
+    check: initialized
+    if not initialized: return
+
+    let
+      symbolBytes = MinBufferSize
+
+    var
+      rsCode = RS(5,5)
+      data = genData(rsCode.data, symbolBytes)
+      parityData: ParityData
+      decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check: decodeRes.isErr
+    if decodeRes.isErr:
+      check: decodeRes.error.code == LeopardBadCode
+
+    rsCode = RS(5,10)
+    data = genData(rsCode.data, symbolBytes)
+    decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check: decodeRes.isErr
+    if decodeRes.isErr:
+      check: decodeRes.error.code == LeopardBadCode
+
+    rsCode = RS(110,10)
+    data = genData(rsCode.data, symbolBytes)
+    decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check: decodeRes.isErr
+    if decodeRes.isErr:
+      check: decodeRes.error.code == LeopardBadCode
+
+  test "should fail if outer length of data does not match the RS code":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize
+      notEnoughData = genData(rsCode.data - 1, symbolBytes)
+      tooMuchData = genData(rsCode.data + 1, symbolBytes)
+      parityData = genData(rsCode.parity, symbolBytes)
+      notEnoughDecodeRes = rsCode.decode(notEnoughData, parityData, symbolBytes)
+      tooMuchDecodeRes = rsCode.decode(tooMuchData, parityData, symbolBytes)
+
+    check:
+        notEnoughDecodeRes.isErr
+        tooMuchDecodeRes.isErr
+    if notEnoughDecodeRes.isErr:
+      check: notEnoughDecodeRes.error.code == LeopardNotEnoughData
+    if tooMuchDecodeRes.isErr:
+      check: tooMuchDecodeRes.error.code == LeopardTooMuchData
+
+  test "should fail if outer length of parityData does not match the RS code":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize
+      data = genData(rsCode.data, symbolBytes)
+      notEnoughParityData = genData(rsCode.parity - 1, symbolBytes)
+      tooMuchParityData = genData(rsCode.parity + 1, symbolBytes)
+      notEnoughDecodeRes = rsCode.decode(data, notEnoughParityData, symbolBytes)
+      tooMuchDecodeRes = rsCode.decode(data, tooMuchParityData, symbolBytes)
+
+    check:
+      notEnoughDecodeRes.isErr
+      tooMuchDecodeRes.isErr
+    if notEnoughDecodeRes.isErr:
+      check: notEnoughDecodeRes.error.code == LeopardNeedMoreData
+    if tooMuchDecodeRes.isErr:
+      check: tooMuchDecodeRes.error.code == LeopardNeedLessData
+
+  test "should fail if symbolBytes is less than minimum buffer size":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize - 5
+      data = genData(rsCode.data, symbolBytes)
+      parityData = genData(rsCode.parity, symbolBytes)
+      decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check: decodeRes.isErr
+    if decodeRes.isErr:
+      check: decodeRes.error.code == LeopardInvalidSize
+
+  test "should fail if symbolBytes is not a multiple of minimum buffer size":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize * 2 + 1
+      data = genData(rsCode.data, symbolBytes)
+      parityData = genData(rsCode.parity, symbolBytes)
+      decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check: decodeRes.isErr
+    if decodeRes.isErr:
+      check: decodeRes.error.code == LeopardInvalidSize
+
+  test "should fail if length of data[0+N] is not zero and does not equal symbolBytes":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize
+      parityData = genData(rsCode.parity, symbolBytes)
+
+    var
+      data = genData(rsCode.data, symbolBytes)
+
+    data[3] = @[1.byte, 2.byte, 3.byte]
+
+    let
+      decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check: decodeRes.isErr
+    if decodeRes.isErr:
+      check: decodeRes.error.code == LeopardInconsistentSize
+
+  test "should fail if there are data losses and length of parityData[0+N] is not zero and does not equal symbolBytes":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize
+
+    var
+      data = genData(rsCode.data, symbolBytes)
+      parityData = genData(rsCode.parity, symbolBytes)
+
+    data[3] = @[]
+    parityData[1] = @[1.byte, 2.byte, 3.byte]
+
+    let
+      decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check: decodeRes.isErr
+    if decodeRes.isErr:
+      check: decodeRes.error.code == LeopardInconsistentSize
+
+  # With the current setup in leopard.nim it seems it's not possible to call
+  # decode with an RS code that would result in leoDecodeWorkCount being called
+  # with invalid parameters, i.e. that would result in it returning 0, because
+  # a Result error will always be returned before leoDecodeWorkCount is called.
+
+  # test "should fail if there are data losses and RS code parameters yield invalid parameters for leoDecodWorkCount":
+  #   check: initialized
+  #   if not initialized: return
+  #
+  #   let
+  #     rsCode = RS(?,?)
+  #     symbolBytes = MinBufferSize
+  #     parityData = genData(rsCode.parity, symbolBytes)
+  #
+  #   var
+  #     data = genData(rsCode.data, symbolBytes)
+  #
+  #   data[0] = @[]
+  #
+  #   let
+  #     decodeRes = rsCode.decode(data, parityData, symbolBytes)
+  #
+  #   check: decodeRes.isErr
+  #   if decodeRes.isErr:
+  #     check: decodeRes.error.code == LeopardInvalidInput
+
+  test "should succeed if there are no data losses even when all parity data is lost":
+    check: initialized
+    if not initialized: return
+
+    let
+      rsCode = RS(8,5)
+      symbolBytes = MinBufferSize
+      data = genData(rsCode.data, symbolBytes)
+
+    var
+      parityData = genData(rsCode.parity, symbolBytes)
+      decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check: decodeRes.isOk
+
+    parityData = genData(rsCode.parity, symbolBytes)
+    parityData[1] = @[]
+    decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check: decodeRes.isOk
+
+    parityData = genData(rsCode.parity, symbolBytes)
+    for i in 0..<parityData.len: parityData[i] = @[]
+    decodeRes = rsCode.decode(data, parityData, symbolBytes)
+
+    check: decodeRes.isOk
+
+suite "Encode + Decode":
+  test "should fail to recover data when losses exceed tolerance":
+    check: initialized
+    if not initialized: return
+
+    var i = 0
+    while i < 1000:
+      let
+        # together dataSymbols = 256+, paritySymbols = 17+, symbolBytes = 64+
+        # seem to consistently trigger parallel processing with OpenMP
+        dataSymbols = rand(256..320)
+        paritySymbols = rand(17..dataSymbols)
+        codewordSymbols = dataSymbols + paritySymbols
+        symbolBytesMultip = rand(1..8)
+        symbolBytes = MinBufferSize * symbolBytesMultip.uint
+        rsCode = RS(codewordSymbols, dataSymbols)
+        data = genData(rsCode.data, symbolBytes)
+        losses = paritySymbols + 1
+        parityDataHoleCount =
+          if (losses - 1) == 0: 0 else: rand(1..(losses - 1))
+        dataHoleCount = losses - parityDataHoleCount
+        encodeRes = rsCode.encode data
+
+      check: dataHoleCount + parityDataHoleCount == losses
+
+      check: encodeRes.isOk
+      if encodeRes.isOk:
+        let
+          parityData = encodeRes.get
+
+        var
+          dataWithHoles = data
+          parityDataWithHoles = parityData
+
+        var
+          dataHoles: seq[int]
+
+        for i in 1..dataHoleCount:
+          while true:
+            let
+              j = rand(dataSymbols - 1)
+
+            if dataHoles.find(j) == -1:
+              dataHoles.add j
+              break
+
+        check: dataHoles.len == dataHoleCount
+
+        for i in dataHoles:
+          dataWithHoles[i] = @[]
+
+        var
+          parityDataHoles: seq[int]
+
+        for i in 1..parityDataHoleCount:
+          while true:
+            let
+              j = rand(paritySymbols - 1)
+
+            if parityDataHoles.find(j) == -1:
+              parityDataHoles.add j
+              break
+
+        check: parityDataHoles.len == parityDataHoleCount
+
+        for i in parityDataHoles:
+          parityDataWithHoles[i] = @[]
+
+        let
+          decodeRes = rsCode.decode(dataWithHoles, parityDataWithHoles,
+            symbolBytes)
+
+        check: decodeRes.isErr
+        if decodeRes.isErr:
+          check: decodeRes.error.code == LeopardNeedMoreData
+
+      else:
+        echo "encode error message: " & encodeRes.error.msg
+
+      inc i
+
+  test "should recover data otherwise":
+    check: initialized
+    if not initialized: return
+
+    var i = 0
+    while i < 1000:
+      let
+        # together dataSymbols = 256+, paritySymbols = 17+, symbolBytes = 64+
+        # seem to consistently trigger parallel processing with OpenMP
+        dataSymbols = rand(256..320)
+        paritySymbols = rand(17..dataSymbols)
+        codewordSymbols = dataSymbols + paritySymbols
+        symbolBytesMultip = rand(1..8)
+        symbolBytes = MinBufferSize * symbolBytesMultip.uint
+        rsCode = RS(codewordSymbols, dataSymbols)
+        data = genData(rsCode.data, symbolBytes)
+        losses = rand(1..paritySymbols)
+        parityDataHoleCount =
+          if (losses - 1) == 0: 0 else: rand(1..(losses - 1))
+        dataHoleCount = losses - parityDataHoleCount
+        encodeRes = rsCode.encode data
+
+      check: dataHoleCount + parityDataHoleCount == losses
+
+      check: encodeRes.isOk
+      if encodeRes.isOk:
+        let
+          parityData = encodeRes.get
+
+        var
+          dataWithHoles = data
+          parityDataWithHoles = parityData
+
+        var
+          dataHoles: seq[int]
+
+        for i in 1..dataHoleCount:
+          while true:
+            let
+              j = rand(dataSymbols - 1)
+
+            if dataHoles.find(j) == -1:
+              dataHoles.add j
+              break
+
+        check: dataHoles.len == dataHoleCount
+
+        for i in dataHoles:
+          dataWithHoles[i] = @[]
+
+        var
+          parityDataHoles: seq[int]
+
+        for i in 1..parityDataHoleCount:
+          while true:
+            let
+              j = rand(paritySymbols - 1)
+
+            if parityDataHoles.find(j) == -1:
+              parityDataHoles.add j
+              break
+
+        check: parityDataHoles.len == parityDataHoleCount
+
+        for i in parityDataHoles:
+          parityDataWithHoles[i] = @[]
+
+        let
+          decodeRes = rsCode.decode(dataWithHoles, parityDataWithHoles,
+            symbolBytes)
+
+        check: decodeRes.isOk
+        if decodeRes.isOk:
+          let
+            decodedData = decodeRes.get
+
+          check:
+            decodedData != dataWithHoles
+            decodedData == data
+
+        else:
+          echo "decode error message: " & decodeRes.error.msg
+
+      else:
+        echo "encode error message: " & encodeRes.error.msg
+
+      inc i
+
+echo ""


### PR DESCRIPTION
nim-leopard provides a Nim wrapper around [Leopard-RS](https://github.com/catid/leopard).

`leopard/wrapper.nim` is a direct wrapper around the C api presented in the upstream's [`leopard.h`](https://github.com/catid/leopard/blob/master/leopard.h).

`leopard.nim` in the root of this repo provides a "Nim API" that encapsulates the lower-level details of `wrapper.nim`, e.g. memory de/allocations and pointer arithmetic.

nim-leopard can be used in both nimble projects and nimbus-build-system projects. Its Leopard-RS submodule is automatically built (in nimcache) and statically linked during compilation of any Nim module that has `import leopard`.

When nim-leopard is installed as a dependency with nimble or when it's a vendor dependency in a nimbus-build-system project, submodule init is handled automatically.

If the nim-leopard repo is cloned locally (to experiment, improve the code, etc.) then before running `nimble develop` or `nimble install` in the root of the clone, it's necessary to init the submodule:
```
$ git submodule update --init
```

[Tests](https://github.com/status-im/nim-leopard/actions) are built/run with Nim v1.2, v1.4, and v1.6 on Linux, macOS, and Windows. They are currently all passing.

---

**NOTES**

[catid/leopard](https://github.com/catid/leopard) has been forked to [status-im/leopard](https://github.com/status-im/leopard) and it is anticipated that some changes will be made in the sources of the latter: allowing for automatic detection of AVX2 in `leopard.h`, etc.

Leopard-RS' [`CMakeLists.txt`](https://github.com/catid/leopard/blob/master/CMakeLists.txt) checks for OpenMP support and if it is available then it is enabled in the build of libleopard. The clang/++ compiler in Apple's Xcode does not support OpenMP, but clang/++ installed with `brew install llvm` does support it, though libomp also needs to be installed with `brew install libomp`.

So, on macOS, when running `nimble test` of nim-leopard or compiling a Nim project that imports nim-leopard:
* If libomp is not installed and Apple clang is used, no extra flags need to be passed to cmake/compiler. OpenMP support will not be enabled in libleopard.
* If libomp is installed and Apple clang is used, this flag should be passed to `nim c`:
  ```
  -d:LeopardCmakeFlags="-DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=off"
  ```
* If the intent is to use brew clang/libomp, the shell environment should be modified:
  ```
  $ export PATH="$(brew --prefix)/opt/llvm/bin:${PATH}"
  $ export LDFLAGS="-L$(brew --prefix)/opt/libomp/lib -L$(brew --prefix)/opt/llvm/lib -Wl,-rpath,$(brew --prefix)/opt/llvm/lib"
  ```
  and these flags should be passed to `nim c`:
  ```
  -d:LeopardCmakeFlags="-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$(brew --prefix)/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix)/opt/llvm/bin/clang++" -d:LeopardExtraCompilerlags="-fopenmp" -d:LeopardExtraLinkerFlags="-fopenmp -L$(brew --prefix)/opt/libomp/lib"
  ```

Comments in `leopard/wrapper.nim` are mostly copied from the upstream. Some inconsistencies and mistakes have been corrected and function/parameter names changed to reflect those of the Nim wrapper.

Since NimScript facilities are not available in `leopard/wrapper.nim`, most of `std/os` is unusable at compile-time. `gorge` and `gorgeEx` are used instead and the shell commands used to prep and build Leopard-RS assume Bash or similar. On Windows `gorge/Ex` spawns `cmd.exe`; however, if  nim/ble was run in e.g. an MSYS2 Bash shell, the environment of `cmd.exe` will inherit from that parent environment and it's possible to get back to Bash with the help of `which bash`. For now, to keep things simpler, nim-leopard assumes that developers on Windows will run nim/ble in a Bash shell and that all needed tools (e.g. cmake) are available and suitable for that environment.

Whether or not parallel processing kicks in per OpenMP depends on the symbol and byte counts. On my local mac, `RS(256,239)` with `symbolBytes == 64` seems to be the lower bound for triggering parallel processing. 

`leopard/wrapper.nim` needs to allocate memory and copy data from `seq`s in order to pass to Leopard-RS the kinds of parameters it expects. Nim v1.2 consistently crashes (on all platforms) for unknown reasons during a call to `alloc/Shared/0` after a number of successful calls. It was suggested in `#dev-helpdesk` of the Nimbus discord to use `c_alloc` and `c_free` instead. Those do not crash in Nim v1.2, so for now Nim's built-in `allocShared` and `deallocShared` are used only with Nim version >= 1.4.

It may, though, be a good idea to use `c_alloc` and `c_free` with all versions of Nim. See this comment in one of @mratsim's libraries:

https://github.com/mratsim/weave/blob/master/weave/memory/allocs.nim#L35-L41

In `#dev-helpdesk` of the Nimbus discord @mratsim provided some examples of aligned allocation:

https://github.com/mratsim/weave/blob/master/weave/memory/allocs.nim#L101-L127

https://github.com/mratsim/Arraymancer/blob/master/src/arraymancer/laser/private/memory.nim#L8-L20

It may be important to consider how those compare/contrast with nim-leopard's current `SIMDSafeAllocate` and `SIMDSafeFree`, which were copied from @dryajov's work in the [leopard2](https://github.com/status-im/nim-dagger/blob/leopard2/tests/dagger/testleopard.nim#L71-L94) branch of nim-dagger.

Memory consumption grows quickly when running `tests/test_leopard`, more so (not surprisingly) when the symbol and byte counts are large. If `benchmark.cpp` in the upstream repo is compiled and run, similar quick growth in memory consumption is observed, but watching it in e.g. Activity Monitor on macOS, the numbers jump up and down as Leopard-RS allocates and frees memory. In the case of the encode+decode tests for nim-leopard, if they're looped e.g. 1 million times, memory consumption grows continually until it hits about 20 GB, then starts being pruned aggressively, dropping back to about 3 GB.

Hopefully there are some change we can make in nim-leopard so that memory gets freed more promptly after encoding/decoding.

Encode+Decode performance on Windows, as observed in CI, is noticeably lower than on macOS and Linux. It could be that even though OpenMP is detected and linked, it's not getting activated at runtime for some reason. It may be related to MSYS2/MinGW vs. Microsoft toolchain, but that's just a guess and can be investigated.

The code in `leopard.nim` can be made more DRY, but it seemed good to wait until e.g. the memory consumption concern is further investigated.

Efficiency of `encode` and `decode` in `leopard.nim` could possibly be improved by using `var` parameters (less copying) and by tweaking how they create `seq`s (don't initialize with `0`s when not necessary). That *might* help sort out the memory consumption concerns, but maybe not (if de/alloc for the arrays of pointers is the main culprit).

Currently, validity checking for RS codes is handled with a helper in `encode` and `decode`. Alternatively, the `RS()` proc could check and raise an exception or return a Result error if a code is invalid. It seemed more ergonomic to check in `encode` and `decode`, but I'm open to doing it the other way.

~nim-leopard's README needs to include basic instructions re: various notes above. They will be added shortly.~ Done.

---

The iterative work that led to this PR is preserved for now on the [`initial_impl_BAK`](https://github.com/status-im/nim-leopard/commits/initial_impl_BAK) branch.

In the [`nim_leopard`](https://github.com/status-im/nim-dagger/tree/nim_leopard) branch of nim-dagger, I've added nim-leopard as a submodule in vendor. I copied `tests/test_leopard.nim` from this repo into `tests/dagger/testleopard.nim` and included it as part of `testAll` to check that with nim-leopard in the mix everything still behaves as expected.