### PR TITLE
[build] Only build `libleopard`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,9 +137,9 @@ jobs:
             touch tests/testleopard
           fi
           if [[ ${{ matrix.platform.os }} = macos ]]; then
-            export PATH="$(brew --prefix)/opt/llvm/bin:${PATH}"
-            export LDFLAGS="-L$(brew --prefix)/opt/libomp/lib -L$(brew --prefix)/opt/llvm/lib -Wl,-rpath,$(brew --prefix)/opt/llvm/lib"
-            compiler_extra_options="-d:LeopardCmakeFlags='-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$(brew --prefix)/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix)/opt/llvm/bin/clang++' -d:LeopardExtraCompilerlags='-fopenmp' -d:LeopardExtraLinkerFlags='-fopenmp -L$(brew --prefix)/opt/libomp/lib'"
+            export PATH="$(brew --prefix llvm@14)/bin:${PATH}"
+            export LDFLAGS="-L$(brew --prefix libomp)/lib -L$(brew --prefix llvm@14)/lib -Wl,-rpath,$(brew --prefix llvm@14)/lib"
+            compiler_extra_options="-d:LeopardCmakeFlags='-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$(brew --prefix llvm@14)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@14)/bin/clang++' -d:LeopardExtraCompilerlags='-fopenmp' -d:LeopardExtraLinkerFlags='-fopenmp -L$(brew --prefix libomp)/lib'"
           fi
           if [[ ${{ matrix.nim_version }} = 1.2.* ]]; then
             eval nimble --verbose test -d:release --gc:refc ${compiler_extra_options}

--- a/leopard/wrapper.nim
+++ b/leopard/wrapper.nim
@@ -123,7 +123,7 @@ static:
       discard bash("mkdir -p", buildDirUnix)
       let cmd =
         @["cd", buildDirUnix, "&& cmake", leopardDirUnix, LeopardCmakeFlags,
-          "&& make"]
+          "&& make libleopard"]
       echo "\nBuilding Leopard-RS: " & cmd.join(" ")
       let (output, exitCode) = bashEx cmd
       echo output
@@ -136,7 +136,7 @@ static:
       discard gorge "mkdir -p " & buildDir
       let cmd =
         "cd " & buildDir & " && cmake " & LeopardDir & " " & LeopardCmakeFlags &
-        " && make"
+        " && make libleopard"
       echo "\nBuilding Leopard-RS: " & cmd
       let (output, exitCode) = gorgeEx cmd
       echo output


### PR DESCRIPTION
Speed up build by not building `bench_leopard` and `experiment_leopard`.

Also fixes build issue in macOS CI.